### PR TITLE
add ability for a user to delete their own comments

### DIFF
--- a/src/components/CommentCard/CommentCard.jsx
+++ b/src/components/CommentCard/CommentCard.jsx
@@ -1,11 +1,16 @@
 import styles from "./CommentCard.module.css"
 import dateConverter from "../../utils/dateConverter";
 import { useEffect, useState } from "react";
-import { getUserInfo } from "../../utils/apis";
+import { getUserInfo, deleteComment} from "../../utils/apis";
+import { useContext } from "react";
+import { UserContext } from "../../contexts/User";
 
 const CommentCard = ({comment}) => {
+    const user = useContext(UserContext).user;
     const [commentAuthorInfo, setCommentAuthorInfo] = useState({});
     const [isLoading, setIsLoading] = useState(true)
+    const [isDeletedComment, setIsDeletedComment] = useState(false);
+    
     useEffect(() => {
         setIsLoading(true)
         getUserInfo(comment.author).then((userInfo) => {
@@ -14,7 +19,13 @@ const CommentCard = ({comment}) => {
         })
     }, [])
 
+    const handleDelete = (e) => {
+        deleteComment(comment.comment_id)
+        setIsDeletedComment(true);
+    }
+
     return (
+        isDeletedComment ? <p className={styles["deleted-comment"]}>Comment Deleted</p> : 
         <li className={styles["comment-card-container"]}>
             <div className={styles["comment-author-container"]}>
                 {isLoading ? <p className={styles["loading-avatar"]}>Loading {comment.author} avatar...</p> : <>
@@ -28,6 +39,8 @@ const CommentCard = ({comment}) => {
                     <p className={styles["date-made"]}>{ comment.created_at ? dateConverter(String(comment.created_at)): null}</p>
                 </div>
                 <p className={styles["comment-body"]}>{comment.body}</p>
+                {user.username === commentAuthorInfo.username ? <button className={styles["btn-delete-comment"]} onClick={handleDelete}>Delete</button> : null}
+            
             </div>
         </li>
     );

--- a/src/components/CommentCard/CommentCard.module.css
+++ b/src/components/CommentCard/CommentCard.module.css
@@ -69,3 +69,18 @@
     height: 100%;
     margin: 0;
 }
+
+.btn-delete-comment {
+    align-self: flex-end;
+    margin-top: 1rem;
+    background-color: rgb(240, 200, 200);
+}
+
+.deleted-comment {
+    color: red;
+    background-color: white;
+    padding: 0.5rem;
+    border: 1px solid black;
+    box-shadow: 1px 1px 3px grey;
+    border-radius: 16px;
+}

--- a/src/components/CommentsList/CommentsList.jsx
+++ b/src/components/CommentsList/CommentsList.jsx
@@ -27,12 +27,13 @@ const CommentsList = () => {
                 <>
                     <h2 className={styles["comments-header"]}>Comments</h2>
                     <ul className={styles["comments-list-container"]}>
-                    <PostCommentForm article_id={article_id}/>
+                        <PostCommentForm article_id={article_id}/>
                         {commentsListArr.map((comment) => {
                             return (
                                 <CommentCard
                                     comment={comment}
-                                key={comment.comment_id}/>
+                                    key={comment.comment_id}
+                                />
                             );
                         })}
                     </ul>

--- a/src/components/PostCommentForm/PostCommentForm.jsx
+++ b/src/components/PostCommentForm/PostCommentForm.jsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import { UserContext } from "../../contexts/User";
 import styles from "./PostCommentForm.module.css";
 import { useState } from "react";
@@ -8,9 +8,8 @@ import CommentCard from "../CommentCard/CommentCard";
 const PostCommentForm = ({ article_id }) => {
     const commentAuthor = useContext(UserContext).user;
     const [newComment, setNewComment] = useState("");
-
     const [addedComment, setAddedComment] = useState([]);
-
+    const [isDeletedComment, setIsDeletedComment] = useState(false);
     const handleNewComment = (e) => {
         setNewComment(e.target.value);
     };
@@ -26,23 +25,25 @@ const PostCommentForm = ({ article_id }) => {
                     article_id: article_id,
                     author: commentAuthor.username,
                     votes: 0,
-                    created_at: 'today',
+                    created_at: "today",
                 };
                 return [
-                    <CommentCard comment={newCommentInfo} key={Date.now()} />, previousComments
+                    <CommentCard comment={newCommentInfo} key={Date.now()} />,
+                    previousComments,
                 ];
             });
-            postComment(article_id, commentAuthor.username, newComment).catch((err) => {
-                setAddedComment((curr) => {
-                    const previousComments = [...curr];
-                    previousComments.shift();
-                    return previousComments;
-                })
-            });
-            setNewComment('');
+            postComment(article_id, commentAuthor.username, newComment).catch(
+                (err) => {
+                    setAddedComment((curr) => {
+                        const previousComments = [...curr];
+                        previousComments.shift();
+                        return previousComments;
+                    });
+                }
+            );
+            setNewComment("");
         }
     };
-
 
     return (
         <>
@@ -69,8 +70,8 @@ const PostCommentForm = ({ article_id }) => {
             </form>
             {addedComment.length !== 0
                 ? addedComment.map((comment) => {
-                    return comment;
-                })
+                      return comment;
+                  })
                 : null}
         </>
     );


### PR DESCRIPTION
A user can now delete their own comments. A button to delete a comment is viewable on the users comments. 

**Before deletion:**
![PreDeletion](https://github.com/mstent/nc-news-fe/assets/151183112/639e2c1a-2504-438b-9b70-8417c28ff821)

**After deletion:**
![postDeletion](https://github.com/mstent/nc-news-fe/assets/151183112/b8b8acb3-8210-446f-8410-5aa03f23cf5f)

Deletion persists in the database after the page is refreshed.

**Page refresh after deletion:**
![deletionPageRefresh](https://github.com/mstent/nc-news-fe/assets/151183112/f0b9f365-d4b4-477d-b6ab-418f9a77b5af)


**Delete button only appears on user comments:** 
![NonUserUnableToDelete](https://github.com/mstent/nc-news-fe/assets/151183112/801a78e6-96a2-4d90-a406-9d1c04425e96)
