### PR TITLE
add abiity to filter articles by topic

### DIFF
--- a/src/components/ArticlesList/ArticlesList.jsx
+++ b/src/components/ArticlesList/ArticlesList.jsx
@@ -3,17 +3,20 @@ import ArticleListCard from '../ArticleListCard/ArticleListCard';
 import { useEffect } from 'react';
 import {getArticles} from '../../utils/apis';
 import styles from './ArticlesList.module.css'
+import { useSearchParams } from 'react-router-dom';
 
 const ArticlesList = () => {
     const [articlesList, setArticlesList] = useState([])
     const [isLoading, setIsLoading] = useState(true)
+    const [searchParams] = useSearchParams();
+    const topic = searchParams.get('topic');
 
     useEffect(() => {
-        getArticles().then((data) => {
+        getArticles(topic).then((data) => {
             setArticlesList(data);
         })
         setIsLoading(false);
-    }, [])
+    }, [topic])
 
     return (
         <div className={styles["article-list-container"]}>

--- a/src/components/TopicsList/TopicsList.jsx
+++ b/src/components/TopicsList/TopicsList.jsx
@@ -1,8 +1,38 @@
+import styles from './TopicsList.module.css'
+import { getTopics } from '../../utils/apis';
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
+
 const TopicsList = () => {
+    const [searchParams] = useSearchParams();
+    const currentTopic = searchParams.get('topic');
+    const [topicsArray, setTopicsArray] = useState([])
+    useEffect(() => {
+        getTopics().then((topics) => {
+            setTopicsArray(topics)
+        })
+    }, [])
+
+    let allTopicsSelected = null;
+    if (!currentTopic) {
+        allTopicsSelected = styles["topic-selected"]
+    } 
+
     return (
-        <div>
-            TopicsList
+        <>
+        <div className={styles["topics-list-container"]}>
+            <Link to={`/`}><li className={[styles["topic"], allTopicsSelected].join(' ')}>All Topics</li></Link>
+            {topicsArray.map((topic) => {
+                let highlight = null
+                if (topic.slug === currentTopic) {
+                    highlight = styles["topic-selected"]
+                }
+                return <Link to={`/?topic=${topic.slug}`}><li key={topic.slug} className={[styles["topic"], highlight].join(" ")}>{topic.slug}</li></Link>
+            })}
         </div>
+            <h3 className={styles["topics-header"]}>Topics</h3>
+        </>
     );
 };
 

--- a/src/components/TopicsList/TopicsList.module.css
+++ b/src/components/TopicsList/TopicsList.module.css
@@ -1,0 +1,49 @@
+.topics-list-container {
+    background-color: lightpink;
+    width: 80%;
+    margin: auto;
+    height: 3rem;
+    border-radius: 15px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    overflow: scroll;
+    padding: 0.4rem;
+    box-shadow: 1px 1px 3px grey;
+    justify-content: flex-start;
+
+}
+
+.topics-header {
+    margin: auto;
+    margin-block: none;
+    text-align: center;
+    background-color: lightpink;
+    box-shadow: 1px 1px 3px grey;
+    width: 6rem;
+    border-radius: 1rem;
+    transform: translateY(-4.6rem);
+}
+
+.topic {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    list-style: none;
+    padding: 0.4rem;
+    background-color: rgb(249, 192, 202);
+    border-radius: 15px;
+    box-shadow: 1px 1px 3px grey;
+    font-weight: bold;
+    border: solid black 1px;
+    white-space: nowrap;
+}
+
+.topic-selected {
+    background-color: darkred;
+    color: white;
+}
+
+a {
+    text-decoration: none;
+    color: black;
+}

--- a/src/utils/apis.jsx
+++ b/src/utils/apis.jsx
@@ -4,11 +4,12 @@ const ncNewsApi = axios.create({
     baseURL: "https://nc-news-23re.onrender.com/api",
 });
 
-const getArticles = () => {
+const getArticles = (topic) => {
     return ncNewsApi
         .get("/articles", {
             params: {
                 limit: "null",
+                topic: topic
             },
         })
         .then(({ data }) => data.articles);
@@ -57,6 +58,14 @@ const deleteComment = (comment_id) => {
     });
 };
 
+const getTopics = () => {
+    return ncNewsApi
+        .get(`/topics`)
+        .then(({ data }) => data.topics)
+        .catch((err) => {
+            return { error: err };
+        });
+};
 export {
     getArticles,
     getUserInfo,
@@ -66,4 +75,5 @@ export {
     removeVote,
     postComment,
     deleteComment,
+    getTopics,
 };


### PR DESCRIPTION
A user can now filter articles via their topic. Initially the topic is set to all so all articles are viewable.

**Initial page viewing and URL:**
![TopicListURL](https://github.com/mstent/nc-news-fe/assets/151183112/ab89f1fc-a10f-438c-a68e-47665f921396)
![TopicList](https://github.com/mstent/nc-news-fe/assets/151183112/cdb500b8-540c-4c9f-8e13-219f56273238)




Clicking on a topic filters the articles and highlights that topic. The URL is also updated but everything is rendered without the whole page being refreshed.

![selectedTopicURL](https://github.com/mstent/nc-news-fe/assets/151183112/af6d97ce-07e5-419c-a883-4a5cff30761b)
**Clicking a topic and new URL:**
![selectedTopic](https://github.com/mstent/nc-news-fe/assets/151183112/fa4fb044-8e83-4872-b655-e6be8c0cc63f)




Refreshing the page preserves the currently selected topic as the updated URL parameter is taken into account when rendering articles, so a user could share the URL with others.